### PR TITLE
更新GitHub Actions工作流，移除主分支推送触发，添加版本提取逻辑以支持开发版本，优化构建命令和文件复制步骤。

### DIFF
--- a/.github/workflows/pyinstaller.yml
+++ b/.github/workflows/pyinstaller.yml
@@ -2,8 +2,6 @@ name: Build and Release
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
 
@@ -30,7 +28,11 @@ jobs:
       - name: Extract version from tag
         id: get_version
         run: |
-          $version = "${{ github.ref }}".Replace('refs/tags/v', '')
+          if ("${{ github.ref }}" -like "refs/tags/v*") {
+            $version = "${{ github.ref }}".Replace('refs/tags/v', '')
+          } else {
+            $version = "dev"
+          }
           echo "version=$version" >> $env:GITHUB_OUTPUT
 
       - name: Install dependencies
@@ -39,11 +41,13 @@ jobs:
           uv add pyinstaller
 
       - name: Build with PyInstaller
-        run: uv run pyinstaller --onefile --name=start${{ steps.get_version.outputs.version }} --icon=resource/icon.ico src/main.py
+        run: uv run pyinstaller --onefile --name=start${{ steps.get_version.outputs.version }} --icon=resource/icon.ico --add-data "bin;bin" src/main.py
 
       - name: Copy additional files
         run: |
-          xcopy /s /i bin dist\bin
+          if (Test-Path "bin") {
+            xcopy /s /i bin dist\bin
+          }
 
       - name: Create Zip Archive
         run: |
@@ -61,7 +65,6 @@ jobs:
           retention-days: 30
 
   release:
-    if: startsWith(github.ref, 'refs/tags/')
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Sourcery 总结

优化 GitHub Actions 工作流，使其仅在版本标签上触发，支持开发构建，增强 PyInstaller 构建步骤，并简化发布任务

增强功能：
- 从标签中提取构建版本，或在开发构建时默认为 'dev'
- 在 PyInstaller 构建中包含额外数据，并使用存在性检查来保护文件复制
- 移除冗余的发布任务条件

CI：
- 将工作流触发器限制为仅版本标签

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine GitHub Actions workflow to trigger only on version tags, support development builds, enhance PyInstaller build steps, and streamline the release job

Enhancements:
- Extract build version from tag or default to 'dev' for development builds
- Include additional data in PyInstaller builds and guard file copy with existence check
- Remove redundant release job condition

CI:
- Restrict workflow triggers to version tags only

</details>