### PR TITLE
Release v3.2.0 - 优化更新检查器和添加音色字典管理

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kinoko7danmaku"
-version = "3.1.0"
+version = "3.2.0"
 requires-python = ">=3.12"
 dependencies = [
     "aiohttp>=3.12.14",

--- a/src/core/qconfig.py
+++ b/src/core/qconfig.py
@@ -95,6 +95,9 @@ class ConfigKey(StrEnum):
     # 别名字典
     ALIAS_DICT = "AliasDict"
 
+    # 音色字典
+    VOICE_DICT = "VoiceDict"
+
 
 class DictValidator(ConfigValidator):
     """字典验证器
@@ -270,6 +273,13 @@ class Config(QConfig):
         group=ConfigGroup.BILI_SERVICE,
         name=ConfigKey.ALIAS_DICT,
         default={"Merlin": "么林"},
+        validator=DictValidator(),
+    )
+
+    voiceDict = ConfigItem(
+        group=ConfigGroup.BILI_SERVICE,
+        name=ConfigKey.VOICE_DICT,
+        default=MINIMAX_VOICE_IDS,
         validator=DictValidator(),
     )
 

--- a/src/core/update_checker.py
+++ b/src/core/update_checker.py
@@ -1,6 +1,9 @@
 """GitHub 更新检查模块"""
 
+import json
 import re
+import time
+from pathlib import Path
 from typing import NamedTuple
 
 import httpx
@@ -23,6 +26,8 @@ class UpdateChecker:
 
     GITHUB_REPO = "MerlinCN/kinoko7danmaku"
     API_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+    CACHE_FILE = Path("data/update_cache.json")
+    CHECK_INTERVAL = 3600 * 1  # 1 小时检查一次
 
     @staticmethod
     def get_current_version() -> str:
@@ -74,46 +79,195 @@ class UpdateChecker:
         return 0
 
     @staticmethod
-    def check_update() -> VersionInfo | None:
+    def _load_cache() -> dict:
+        """加载缓存数据
+
+        Returns:
+            缓存字典，包含 etag、last_check_time 和 latest_version
+        """
+        if not UpdateChecker.CACHE_FILE.exists():
+            return {}
+
+        try:
+            with open(UpdateChecker.CACHE_FILE, encoding="utf-8") as f:
+                return json.load(f)
+        except Exception as e:
+            logger.warning(f"读取更新缓存失败: {e}")
+            return {}
+
+    @staticmethod
+    def _save_cache(
+        etag: str | None,
+        last_check_time: float,
+        latest_version: str | None = None,
+        release_info: dict | None = None,
+    ) -> None:
+        """保存缓存数据
+
+        Args:
+            etag: ETag 值
+            last_check_time: 上次检查时间戳
+            latest_version: 上次检测到的最新版本号
+            release_info: 发布信息（download_url、release_notes、release_url）
+        """
+        try:
+            UpdateChecker.CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+            cache_data = {
+                "etag": etag,
+                "last_check_time": last_check_time,
+                "latest_version": latest_version,
+                "release_info": release_info,
+            }
+            with open(UpdateChecker.CACHE_FILE, "w", encoding="utf-8") as f:
+                json.dump(cache_data, f, indent=4, ensure_ascii=False)
+        except Exception as e:
+            logger.warning(f"保存更新缓存失败: {e}")
+
+    @staticmethod
+    def _check_version_from_cache(
+        current_version: str,
+        cached_latest_version: str | None,
+        cached_release_info: dict | None,
+    ) -> VersionInfo | None:
+        """从缓存中检查版本更新
+
+        Args:
+            current_version: 当前版本号
+            cached_latest_version: 缓存的最新版本号
+            cached_release_info: 缓存的发布信息
+
+        Returns:
+            如果有新版本，返回 VersionInfo；否则返回 None
+        """
+        if not cached_latest_version:
+            logger.info(f"当前已是最新版本: {current_version}")
+            return None
+
+        if UpdateChecker.compare_versions(cached_latest_version, current_version) > 0:
+            logger.info(
+                f"发现新版本: {cached_latest_version} (当前版本: {current_version})（来自缓存）"
+            )
+            if cached_release_info:
+                return VersionInfo(
+                    version=cached_latest_version,
+                    download_url=cached_release_info.get("download_url", ""),
+                    release_notes=cached_release_info.get("release_notes", ""),
+                    release_url=cached_release_info.get("release_url", ""),
+                )
+        else:
+            logger.info(f"当前已是最新版本: {current_version}")
+
+        return None
+
+    @staticmethod
+    def check_update(force: bool = False) -> VersionInfo | None:
         """检查是否有新版本
+
+        Args:
+            force: 是否强制检查（忽略检查间隔）
 
         Returns:
             如果有新版本，返回 VersionInfo；否则返回 None
         """
         current_version = UpdateChecker.get_current_version()
+        current_time = time.time()
 
+        # 加载缓存
+        cache = UpdateChecker._load_cache()
+        last_check_time = cache.get("last_check_time", 0)
+        etag = cache.get("etag")
+        cached_latest_version = cache.get("latest_version")
+        cached_release_info = cache.get("release_info")
+
+        # 检查是否需要 API 请求（距离上次检查时间）
+        should_skip_api = (
+            not force
+            and (current_time - last_check_time) < UpdateChecker.CHECK_INTERVAL
+        )
+
+        if should_skip_api:
+            logger.info(
+                f"距离上次检查不足 {UpdateChecker.CHECK_INTERVAL / 3600:.1f} 小时，跳过 API 请求"
+            )
+            # 即使跳过 API 请求，也要检查缓存中的版本
+            return UpdateChecker._check_version_from_cache(
+                current_version, cached_latest_version, cached_release_info
+            )
+
+        # 发起 API 请求
         try:
-            response = httpx.get(UpdateChecker.API_URL)
-            response.raise_for_status()
-            data = response.json()
+            headers = {"If-None-Match": etag} if etag else {}
+            response = httpx.get(UpdateChecker.API_URL, headers=headers, timeout=10.0)
 
-            # 获取最新版本号
+            # 403 限流：返回缓存
+            if response.status_code == 403:
+                logger.warning("GitHub API 限流，使用缓存数据")
+                return UpdateChecker._check_version_from_cache(
+                    current_version, cached_latest_version, cached_release_info
+                )
+
+            # 304 未修改：更新检查时间，返回缓存
+            if response.status_code == 304:
+                UpdateChecker._save_cache(
+                    etag, current_time, cached_latest_version, cached_release_info
+                )
+                return UpdateChecker._check_version_from_cache(
+                    current_version, cached_latest_version, cached_release_info
+                )
+
+            # 检查其他 HTTP 错误
+            response.raise_for_status()
+
+            # 解析新版本数据
+            data = response.json()
             latest_version = data.get("tag_name", "")
             if not latest_version:
                 logger.warning("GitHub API 返回的版本号为空")
                 return None
 
-            # 比较版本号
+            # 保存到缓存
+            new_etag = response.headers.get("etag", etag)
+            release_info = {
+                "download_url": data.get("html_url", ""),
+                "release_notes": data.get("body", ""),
+                "release_url": data.get("html_url", ""),
+            }
+            UpdateChecker._save_cache(
+                new_etag, current_time, latest_version, release_info
+            )
+
+            # 比较版本
             if UpdateChecker.compare_versions(latest_version, current_version) <= 0:
                 logger.info(f"当前已是最新版本: {current_version}")
                 return None
 
-            # 查找 Windows 可执行文件的下载链接
-            download_url = data.get("html_url", "")
-
-            version_info = VersionInfo(
+            logger.info(f"发现新版本: {latest_version} (当前版本: {current_version})")
+            return VersionInfo(
                 version=latest_version,
-                download_url=download_url,
-                release_notes=data.get("body", ""),
-                release_url=data.get("html_url", ""),
+                download_url=release_info["download_url"],
+                release_notes=release_info["release_notes"],
+                release_url=release_info["release_url"],
             )
 
-            logger.info(f"发现新版本: {latest_version} (当前版本: {current_version})")
-            return version_info
-
+        except httpx.TimeoutException:
+            logger.warning("检查更新超时，使用缓存数据")
+            return UpdateChecker._check_version_from_cache(
+                current_version, cached_latest_version, cached_release_info
+            )
+        except httpx.HTTPStatusError as e:
+            logger.warning(
+                f"检查更新时 HTTP 错误: {e.response.status_code}，使用缓存数据"
+            )
+            return UpdateChecker._check_version_from_cache(
+                current_version, cached_latest_version, cached_release_info
+            )
         except httpx.HTTPError as e:
-            logger.exception(f"检查更新时网络错误: {e}")
-            return None
+            logger.warning(f"检查更新时网络错误: {e}，使用缓存数据")
+            return UpdateChecker._check_version_from_cache(
+                current_version, cached_latest_version, cached_release_info
+            )
         except Exception as e:
-            logger.exception(f"检查更新时发生错误: {e}")
-            return None
+            logger.warning(f"检查更新时发生错误: {e}，使用缓存数据")
+            return UpdateChecker._check_version_from_cache(
+                current_version, cached_latest_version, cached_release_info
+            )

--- a/src/gui/components/__init__.py
+++ b/src/gui/components/__init__.py
@@ -1,5 +1,6 @@
 from .alias_dict_card import AliasDictCard
 from .danmaku_control_card import DanmakuControlCard
+from .dict_edit_card import DictEditCard
 from .float_range_setting_card import FloatRangeSettingCard
 from .home_panel import HomePanel
 from .int_setting_card import IntSettingCard
@@ -11,6 +12,7 @@ from .user_info_card import UserInfoCard
 __all__ = [
     "AliasDictCard",
     "DanmakuControlCard",
+    "DictEditCard",
     "FloatRangeSettingCard",
     "HomePanel",
     "IntSettingCard",
@@ -19,4 +21,3 @@ __all__ = [
     "StrSettingCard",
     "UserInfoCard",
 ]
-

--- a/src/gui/components/alias_dict_card.py
+++ b/src/gui/components/alias_dict_card.py
@@ -1,116 +1,17 @@
 """别名字典设置卡片"""
 
-from PySide6.QtCore import Signal
-from PySide6.QtWidgets import QHBoxLayout, QWidget
-from qfluentwidgets import BodyLabel, ExpandGroupSettingCard, LineEdit, ToolButton
+from PySide6.QtWidgets import QWidget
 from qfluentwidgets import FluentIcon as FIF
 
 from core.qconfig import cfg
 
-
-class AliasItemWidget(QWidget):
-    """别名项组件
-
-    包含原词和替换词的输入框，以及添加/删除按钮。
-    """
-
-    # 信号
-    deleteRequested = Signal(QWidget)  # 删除请求信号
-    addRequested = Signal()  # 添加请求信号
-    valueChanged = Signal()  # 值改变信号
-
-    def __init__(
-        self, key: str = "", value: str = "", parent: QWidget | None = None
-    ) -> None:
-        """初始化别名项组件
-
-        Args:
-            key: 别名键（原词）
-            value: 别名值（替换为）
-            parent: 父组件
-        """
-        super().__init__(parent=parent)
-        self._init_ui(key, value)
-
-    def _init_ui(self, key: str, value: str) -> None:
-        """初始化 UI
-
-        Args:
-            key: 别名键
-            value: 别名值
-        """
-        # 主布局
-        layout = QHBoxLayout(self)
-        layout.setContentsMargins(48, 12, 48, 12)
-        layout.setSpacing(12)
-
-        # 原词标签
-        self.key_label = BodyLabel("原词：", self)
-        layout.addWidget(self.key_label)
-
-        # 原词输入框
-        self.key_edit = LineEdit(self)
-        self.key_edit.setText(key)
-        self.key_edit.setPlaceholderText("输入原词")
-        self.key_edit.setFixedWidth(150)
-        self.key_edit.textChanged.connect(self._on_value_changed)
-        layout.addWidget(self.key_edit)
-
-        layout.addSpacing(16)
-
-        # 替换为标签
-        self.value_label = BodyLabel("替换为：", self)
-        layout.addWidget(self.value_label)
-
-        # 替换为输入框
-        self.value_edit = LineEdit(self)
-        self.value_edit.setText(value)
-        self.value_edit.setPlaceholderText("输入替换词")
-        self.value_edit.setFixedWidth(150)
-        self.value_edit.textChanged.connect(self._on_value_changed)
-        layout.addWidget(self.value_edit)
-
-        layout.addStretch()
-
-        # 删除/添加按钮（初始隐藏，由父组件控制）
-        self.delete_btn = ToolButton(FIF.REMOVE, self)
-        self.delete_btn.clicked.connect(lambda: self.deleteRequested.emit(self))
-        layout.addWidget(self.delete_btn)
-
-        self.add_btn = ToolButton(FIF.ADD, self)
-        self.add_btn.clicked.connect(self.addRequested.emit)
-        layout.addWidget(self.add_btn)
-        self.add_btn.hide()  # 默认隐藏
-
-        self.setFixedHeight(60)
-
-    def _on_value_changed(self) -> None:
-        """值改变时发射信号"""
-        self.valueChanged.emit()
-
-    def get_key(self) -> str:
-        """获取别名键"""
-        return self.key_edit.text().strip()
-
-    def get_value(self) -> str:
-        """获取别名值"""
-        return self.value_edit.text().strip()
-
-    def set_button_mode(self, show_add: bool, show_delete: bool) -> None:
-        """设置按钮显示模式
-
-        Args:
-            show_add: 是否显示添加按钮
-            show_delete: 是否显示删除按钮
-        """
-        self.add_btn.setVisible(show_add)
-        self.delete_btn.setVisible(show_delete)
+from .dict_edit_card import DictEditCard
 
 
-class AliasDictCard(ExpandGroupSettingCard):
+class AliasDictCard(DictEditCard):
     """别名字典设置卡片
 
-    使用可展开的组设置卡片显示和管理别名字典。
+    继承自 DictEditCard，使用通用的字典编辑功能。
     """
 
     def __init__(self, parent: QWidget | None = None) -> None:
@@ -120,116 +21,13 @@ class AliasDictCard(ExpandGroupSettingCard):
             parent: 父组件
         """
         super().__init__(
+            config_item=cfg.aliasDict,
             icon=FIF.BOOK_SHELF,
             title="别名字典",
             content="设置弹幕中的别名替换规则",
+            key_label="原词",
+            value_label="替换为",
+            key_placeholder="输入原词",
+            value_placeholder="输入替换词",
             parent=parent,
         )
-        self.alias_items = []  # 存储别名项组件
-        self._load_aliases()
-
-    def _load_aliases(self) -> None:
-        """从配置加载别名并创建组件"""
-        # 获取别名字典
-        alias_dict = cfg.aliasDict.value
-
-        # 清空现有组件
-        self._clear_items()
-
-        # 为每个别名创建组件
-        if alias_dict:
-            for key, value in alias_dict.items():
-                self._add_alias_item(key, value)
-        else:
-            # 如果没有别名，添加一个空项
-            self._add_alias_item("", "")
-
-        # 更新按钮状态
-        self._update_button_states()
-
-    def _add_alias_item(self, key: str, value: str) -> None:
-        """添加一个别名项
-
-        Args:
-            key: 别名键
-            value: 别名值
-        """
-        item = AliasItemWidget(key, value, self)
-        # 连接信号
-        item.deleteRequested.connect(self._on_delete_item)
-        item.addRequested.connect(self._on_add_item)
-        item.valueChanged.connect(self._on_value_changed)
-
-        self.alias_items.append(item)
-        self.addGroupWidget(item)
-
-    def _on_add_item(self) -> None:
-        """添加按钮点击事件"""
-        # 添加一个新的空项
-        self._add_alias_item("", "")
-        # 更新按钮状态
-        self._update_button_states()
-        # 保存到配置
-        self._save_to_config()
-
-    def _on_delete_item(self, item: QWidget) -> None:
-        """删除按钮点击事件
-
-        Args:
-            item: 要删除的别名项
-        """
-        if item in self.alias_items:
-            self.alias_items.remove(item)
-            self.removeGroupWidget(item)
-            item.deleteLater()
-
-            # 如果删除后没有项了，添加一个空项
-            if not self.alias_items:
-                self._add_alias_item("", "")
-
-            # 更新按钮状态
-            self._update_button_states()
-            # 保存到配置
-            self._save_to_config()
-
-    def _on_value_changed(self) -> None:
-        """值改变时保存到配置"""
-        self._save_to_config()
-
-    def _update_button_states(self) -> None:
-        """更新所有别名项的按钮状态"""
-        count = len(self.alias_items)
-
-        for i, item in enumerate(self.alias_items):
-            is_last = i == count - 1
-            show_delete = count > 1  # 只有一条时不显示删除按钮
-            show_add = is_last  # 只有最后一条显示添加按钮
-
-            item.set_button_mode(show_add, show_delete)
-
-    def _save_to_config(self) -> None:
-        """保存别名字典到配置
-
-        只保存原词和替换词都不为空的项。
-        """
-        # 收集所有有效的别名（原词和替换词都不为空）
-        alias_dict = {}
-        for item in self.alias_items:
-            key = item.get_key()
-            value = item.get_value()
-            if key and value:  # 两者都不为空才保存
-                alias_dict[key] = value
-
-        # 保存到配置
-        cfg.set(cfg.aliasDict, alias_dict)
-
-    def _clear_items(self) -> None:
-        """清空所有别名项"""
-        for item in self.alias_items:
-            self.removeGroupWidget(item)
-            item.deleteLater()
-        self.alias_items.clear()
-
-    def reload(self) -> None:
-        """重新加载别名字典"""
-        self._load_aliases()

--- a/src/gui/components/dict_edit_card.py
+++ b/src/gui/components/dict_edit_card.py
@@ -1,0 +1,298 @@
+"""通用字典编辑设置卡片"""
+
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QHBoxLayout, QWidget
+from qfluentwidgets import (
+    BodyLabel,
+    ConfigItem,
+    ExpandGroupSettingCard,
+    LineEdit,
+    ToolButton,
+)
+from qfluentwidgets import FluentIcon as FIF
+
+from core.qconfig import cfg
+
+
+class DictItemWidget(QWidget):
+    """字典项组件
+
+    包含键和值的输入框，以及添加/删除按钮。
+    """
+
+    # 信号
+    deleteRequested = Signal(QWidget)  # 删除请求信号
+    addRequested = Signal()  # 添加请求信号
+    valueChanged = Signal()  # 值改变信号
+
+    def __init__(
+        self,
+        key: str = "",
+        value: str = "",
+        key_label: str = "键",
+        value_label: str = "值",
+        key_placeholder: str = "输入键",
+        value_placeholder: str = "输入值",
+        parent: QWidget | None = None,
+    ) -> None:
+        """初始化字典项组件
+
+        Args:
+            key: 字典键
+            value: 字典值
+            key_label: 键标签文本
+            value_label: 值标签文本
+            key_placeholder: 键输入框占位符
+            value_placeholder: 值输入框占位符
+            parent: 父组件
+        """
+        super().__init__(parent=parent)
+        self._init_ui(
+            key, value, key_label, value_label, key_placeholder, value_placeholder
+        )
+
+    def _init_ui(
+        self,
+        key: str,
+        value: str,
+        key_label: str,
+        value_label: str,
+        key_placeholder: str,
+        value_placeholder: str,
+    ) -> None:
+        """初始化 UI
+
+        Args:
+            key: 字典键
+            value: 字典值
+            key_label: 键标签文本
+            value_label: 值标签文本
+            key_placeholder: 键输入框占位符
+            value_placeholder: 值输入框占位符
+        """
+        # 主布局
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(48, 12, 48, 12)
+        layout.setSpacing(12)
+
+        # 键标签
+        self.key_label = BodyLabel(f"{key_label}：", self)
+        layout.addWidget(self.key_label)
+
+        # 键输入框
+        self.key_edit = LineEdit(self)
+        self.key_edit.setText(key)
+        self.key_edit.setPlaceholderText(key_placeholder)
+        self.key_edit.setFixedWidth(150)
+        self.key_edit.textChanged.connect(self._on_value_changed)
+        layout.addWidget(self.key_edit)
+
+        layout.addSpacing(16)
+
+        # 值标签
+        self.value_label = BodyLabel(f"{value_label}：", self)
+        layout.addWidget(self.value_label)
+
+        # 值输入框
+        self.value_edit = LineEdit(self)
+        self.value_edit.setText(value)
+        self.value_edit.setPlaceholderText(value_placeholder)
+        self.value_edit.setFixedWidth(150)
+        self.value_edit.textChanged.connect(self._on_value_changed)
+        layout.addWidget(self.value_edit)
+
+        layout.addStretch()
+
+        # 删除/添加按钮（初始隐藏，由父组件控制）
+        self.delete_btn = ToolButton(FIF.REMOVE, self)
+        self.delete_btn.clicked.connect(lambda: self.deleteRequested.emit(self))
+        layout.addWidget(self.delete_btn)
+
+        self.add_btn = ToolButton(FIF.ADD, self)
+        self.add_btn.clicked.connect(self.addRequested.emit)
+        layout.addWidget(self.add_btn)
+        self.add_btn.hide()  # 默认隐藏
+
+        self.setFixedHeight(60)
+
+    def _on_value_changed(self) -> None:
+        """值改变时发射信号"""
+        self.valueChanged.emit()
+
+    def get_key(self) -> str:
+        """获取字典键"""
+        return self.key_edit.text().strip()
+
+    def get_value(self) -> str:
+        """获取字典值"""
+        return self.value_edit.text().strip()
+
+    def set_button_mode(self, show_add: bool, show_delete: bool) -> None:
+        """设置按钮显示模式
+
+        Args:
+            show_add: 是否显示添加按钮
+            show_delete: 是否显示删除按钮
+        """
+        self.add_btn.setVisible(show_add)
+        self.delete_btn.setVisible(show_delete)
+
+
+class DictEditCard(ExpandGroupSettingCard):
+    """通用字典编辑设置卡片
+
+    使用可展开的组设置卡片显示和管理字典。
+    """
+
+    def __init__(
+        self,
+        config_item: ConfigItem,
+        icon,
+        title: str,
+        content: str,
+        key_label: str = "键",
+        value_label: str = "值",
+        key_placeholder: str = "输入键",
+        value_placeholder: str = "输入值",
+        parent: QWidget | None = None,
+    ) -> None:
+        """初始化字典编辑卡片
+
+        Args:
+            config_item: 配置项（必须是字典类型）
+            icon: 图标
+            title: 标题
+            content: 描述
+            key_label: 键标签文本
+            value_label: 值标签文本
+            key_placeholder: 键输入框占位符
+            value_placeholder: 值输入框占位符
+            parent: 父组件
+        """
+        super().__init__(
+            icon=icon,
+            title=title,
+            content=content,
+            parent=parent,
+        )
+        self.config_item = config_item
+        self.key_label = key_label
+        self.value_label = value_label
+        self.key_placeholder = key_placeholder
+        self.value_placeholder = value_placeholder
+        self.dict_items = []  # 存储字典项组件
+        self._load_dict()
+
+    def _load_dict(self) -> None:
+        """从配置加载字典并创建组件"""
+        # 获取字典
+        dict_value = self.config_item.value
+
+        # 清空现有组件
+        self._clear_items()
+
+        # 为每个键值对创建组件
+        if dict_value:
+            for key, value in dict_value.items():
+                self._add_dict_item(key, value)
+        else:
+            # 如果字典为空，添加一个空项
+            self._add_dict_item("", "")
+
+        # 更新按钮状态
+        self._update_button_states()
+
+    def _add_dict_item(self, key: str, value: str) -> None:
+        """添加一个字典项
+
+        Args:
+            key: 字典键
+            value: 字典值
+        """
+        item = DictItemWidget(
+            key,
+            value,
+            self.key_label,
+            self.value_label,
+            self.key_placeholder,
+            self.value_placeholder,
+            self,
+        )
+        # 连接信号
+        item.deleteRequested.connect(self._on_delete_item)
+        item.addRequested.connect(self._on_add_item)
+        item.valueChanged.connect(self._on_value_changed)
+
+        self.dict_items.append(item)
+        self.addGroupWidget(item)
+
+    def _on_add_item(self) -> None:
+        """添加按钮点击事件"""
+        # 添加一个新的空项
+        self._add_dict_item("", "")
+        # 更新按钮状态
+        self._update_button_states()
+        # 保存到配置
+        self._save_to_config()
+
+    def _on_delete_item(self, item: QWidget) -> None:
+        """删除按钮点击事件
+
+        Args:
+            item: 要删除的字典项
+        """
+        if item in self.dict_items:
+            self.dict_items.remove(item)
+            self.removeGroupWidget(item)
+            item.deleteLater()
+
+            # 如果删除后没有项了，添加一个空项
+            if not self.dict_items:
+                self._add_dict_item("", "")
+
+            # 更新按钮状态
+            self._update_button_states()
+            # 保存到配置
+            self._save_to_config()
+
+    def _on_value_changed(self) -> None:
+        """值改变时保存到配置"""
+        self._save_to_config()
+
+    def _update_button_states(self) -> None:
+        """更新所有字典项的按钮状态"""
+        count = len(self.dict_items)
+
+        for i, item in enumerate(self.dict_items):
+            is_last = i == count - 1
+            show_delete = count > 1  # 只有一条时不显示删除按钮
+            show_add = is_last  # 只有最后一条显示添加按钮
+
+            item.set_button_mode(show_add, show_delete)
+
+    def _save_to_config(self) -> None:
+        """保存字典到配置
+
+        只保存键和值都不为空的项。
+        """
+        # 收集所有有效的键值对（键和值都不为空）
+        dict_value = {}
+        for item in self.dict_items:
+            key = item.get_key()
+            value = item.get_value()
+            if key and value:  # 两者都不为空才保存
+                dict_value[key] = value
+
+        # 保存到配置
+        cfg.set(self.config_item, dict_value)
+
+    def _clear_items(self) -> None:
+        """清空所有字典项"""
+        for item in self.dict_items:
+            self.removeGroupWidget(item)
+            item.deleteLater()
+        self.dict_items.clear()
+
+    def reload(self) -> None:
+        """重新加载字典"""
+        self._load_dict()

--- a/src/gui/view/main.py
+++ b/src/gui/view/main.py
@@ -203,7 +203,7 @@ class MainWindow(FluentWindow):
             routeKey="update",
             icon=FIF.UPDATE,
             text="更新",
-            onClick=self._on_update,
+            onClick=lambda: self._on_update(is_force=True),
             selectable=False,
             tooltip="更新",
             position=NavigationItemPosition.BOTTOM,
@@ -234,10 +234,10 @@ class MainWindow(FluentWindow):
         )
 
     @asyncSlot()
-    async def _on_update(self) -> None:
+    async def _on_update(self, is_force: bool = False) -> None:
         """更新"""
         self.progress_ring.start()
-        version_info = await asyncio.to_thread(UpdateChecker.check_update)
+        version_info = await asyncio.to_thread(UpdateChecker.check_update, is_force)
         self.progress_ring.stop()
         if version_info:
             w = InfoBar.new(

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "kinoko7danmaku"
-version = "3.0.0"
+version = "3.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## 主要更新

### 1. 优化更新检查器，解决 GitHub API 限流问题

**核心改进：**
- ✅ 添加 ETag 条件请求机制，304 响应不计入 API 限流配额
- ✅ 实现缓存机制（`data/update_cache.json`），保存版本信息和 ETag
- ✅ 设置检查间隔（1 小时），避免频繁 API 调用
- ✅ 提取 `_check_version_from_cache()` 方法，统一处理缓存版本比较
- ✅ 所有错误场景（限流/超时/网络错误）都优雅降级到缓存
- ✅ 跳过 API 请求时仍然检查并返回缓存中的更新信息

**技术细节：**
- ETag 条件请求：首次请求保存 ETag，后续请求带 `If-None-Match` 头
- 缓存结构：`etag + last_check_time + latest_version + release_info`
- 优雅降级：任何错误都尝试从缓存获取版本信息，不会崩溃

**解决问题：**
- ✅ 未认证请求限流（60次/小时）导致的 403 错误
- ✅ 频繁检查导致的 API 配额消耗  
- ✅ 无需 Token，适合多用户使用的桌面应用

### 2. 添加音色字典管理功能

**新增组件：**
- 新建 `DictEditCard` 组件（`src/gui/components/dict_edit_card.py`）
- 重构别名字典卡片（`alias_dict_card.py`），复用 `DictEditCard`
- 在设置页面添加音色字典配置入口

**功能特性：**
- ✅ 可视化编辑音色字典（key-value 对）
- ✅ 支持添加、删除、修改音色映射
- ✅ 实时保存到配置文件
- ✅ 优化用户界面体验

## 测试

### 更新检查器测试
- ✅ 首次 API 请求并保存缓存
- ✅ 304 响应时使用缓存数据
- ✅ 跳过 API 时仍返回缓存更新信息
- ✅ 当前版本已是最新时正确返回

### GUI 测试
- ✅ 音色字典编辑功能正常
- ✅ 配置保存和读取正常

## 文件变更

- **新增**: `src/gui/components/dict_edit_card.py` (298 行)
- **优化**: `src/core/update_checker.py` (+192 行)
- **重构**: `src/gui/components/alias_dict_card.py` (-220 行，复用新组件)
- **增强**: `src/gui/view/settings.py` (+62 行)

## 版本

v3.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 总结

优化发布流程，通过改进更新检查器以使用基于 ETag 的缓存和间隔限制，并引入一个可重用的字典编辑卡片，应用于设置 UI 中的别名和语音字典。

新功能:
- 引入通用字典编辑组件 (DictEditCard) 并将其集成到别名和语音字典中
- 增强更新检查器，支持 ETag 条件请求、持久缓存和一小时检查间隔

错误修复:
- 通过回退到缓存并使用 304 响应来处理 GitHub API 速率限制

改进:
- 重构 AliasDictCard 以继承 DictEditCard
- 根据设置 UI 中语音字典的更改动态更新语音 ID 选项
- 允许通过 UI 强制检查更新

测试:
- 为更新检查器缓存和条件请求添加测试
- 为字典编辑和配置持久性添加 GUI 测试

杂项:
- 将项目版本提升至 3.2.0

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize the release process by improving the update checker to use ETag-based caching and interval throttling, and introduce a reusable dictionary editing card applied to both alias and voice dictionaries in the settings UI.

New Features:
- Introduce generic dictionary editing component (DictEditCard) and integrate it for alias and voice dictionaries
- Enhance update checker with ETag conditional requests, persistent caching, and one-hour check interval

Bug Fixes:
- Handle GitHub API rate limiting by falling back to cache and using 304 responses

Enhancements:
- Refactor AliasDictCard to inherit from DictEditCard
- Dynamically update voice ID options based on voice dictionary changes in settings UI
- Allow forced update checks via UI

Tests:
- Add tests for update checker caching and conditional requests
- Add GUI tests for dictionary editing and configuration persistence

Chores:
- Bump project version to 3.2.0

</details>