### PR TITLE
修复自定义音色无法被加载

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kinoko7danmaku"
-version = "3.3.0"
+version = "3.3.1"
 requires-python = ">=3.12"
 dependencies = [
     "aiohttp>=3.12.14",

--- a/src/gui/view/settings.py
+++ b/src/gui/view/settings.py
@@ -252,7 +252,6 @@ class SettingsInterface(ScrollArea):
             value_placeholder="输入显示名称",
             parent=self.minimaxGroup,
         )
-
         self.minimaxVoiceIdCard = ComboBoxSettingCard(
             configItem=cfg.minimaxVoiceId,
             icon=FIF.MICROPHONE,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "kinoko7danmaku"
-version = "3.2.0"
+version = "3.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- 修复自定义音色无法被加载的问题
- 更新版本号到 3.3.1

## Changes
- 修复 `src/core/qconfig.py` 中的音色加载逻辑
- 更新 `pyproject.toml` 版本号

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 总结

通过引入语音 ID 的动态验证并在配置加载后更新设置来修复自定义语音加载问题

Bug 修复:
- 通过根据动态 voiceDict 条目而非静态列表进行验证，防止自定义语音 ID 重置为默认值

改进:
- 添加 VoiceIdValidator 以根据当前的 voiceDict 验证和更正语音 ID
- 在配置加载后重新分配 minimaxVoiceId 验证器和默认值，以支持用户添加的语音

构建:
- 将项目版本升级到 3.3.1

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix custom voice loading by introducing dynamic validation of voice IDs and updating settings after configuration load

Bug Fixes:
- Prevent custom voice IDs from resetting to default by validating against dynamic voiceDict entries instead of static list

Enhancements:
- Add VoiceIdValidator to validate and correct voice IDs based on current voiceDict
- Reassign minimaxVoiceId validator and default value after config load to support user-added voices

Build:
- Bump project version to 3.3.1

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables dynamic loading/validation of custom Minimax voice IDs from voiceDict and updates the settings UI to reflect changes, plus bumps version to 3.3.1.
> 
> - **Core (qconfig)**:
>   - Add `VoiceIdValidator` that validates `minimaxVoiceId` against `cfg.voiceDict`.
>   - Set `minimaxVoiceId` default to `list(voiceDict.value.keys())[0]` and use dynamic validator.
>   - After loading config, refresh validator with `OptionsValidator(list(cfg.voiceDict.value.keys()))` and coerce value to a valid option.
> - **UI (settings)**:
>   - Connect `cfg.voiceDict.valueChanged` to update Minimax voice options.
>   - Rebuild `minimaxVoiceId` combo items from `voiceDict` (ID->name mapping) and keep selection valid.
> - **Version**: bump `pyproject.toml` to `3.3.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e8e3bba4630cec1b4e495f4c5d1b97e4da8e959. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->