### PR TITLE
修复启动报错

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kinoko7danmaku"
-version = "3.3.1"
+version = "3.3.2"
 requires-python = ">=3.12"
 dependencies = [
     "aiohttp>=3.12.14",

--- a/src/core/qconfig.py
+++ b/src/core/qconfig.py
@@ -175,7 +175,7 @@ class OutputDeviceValidator(OptionsValidator):
         return value if self.validate(value) else self.options[0]
 
 
-class VoiceIdValidator(ConfigValidator):
+class VoiceIdValidator(OptionsValidator):
     """音色 ID 验证器
 
     动态从 voiceDict 获取可用的音色 ID 列表进行验证。
@@ -190,6 +190,8 @@ class VoiceIdValidator(ConfigValidator):
             voice_dict_config_item: voiceDict 的 ConfigItem 实例
         """
         self.voice_dict_config_item = voice_dict_config_item
+        # 初始化父类，设置初始 options
+        super().__init__(list(voice_dict_config_item.value.keys()))
 
     @override
     def validate(self, value) -> bool:
@@ -551,3 +553,7 @@ cfg = Config()
 
 # 加载配置文件
 qconfig.load("data/config.json", cfg)
+
+cfg.minimaxVoiceId.validator = VoiceIdValidator(cfg.voiceDict)
+if cfg.minimaxVoiceId.value not in cfg.minimaxVoiceId.options:
+    cfg.minimaxVoiceId.value = cfg.minimaxVoiceId.options[0]

--- a/src/core/qconfig.py
+++ b/src/core/qconfig.py
@@ -551,9 +551,3 @@ cfg = Config()
 
 # 加载配置文件
 qconfig.load("data/config.json", cfg)
-
-# 动态更新音色 ID validator，以支持用户自定义的音色
-# 必须在加载配置后立即更新，否则用户自定义的音色 ID 会被重置为默认值
-cfg.minimaxVoiceId.validator = OptionsValidator(list(cfg.voiceDict.value.keys()))
-if cfg.minimaxVoiceId.value not in cfg.minimaxVoiceId.validator.options:
-    cfg.minimaxVoiceId.value = cfg.minimaxVoiceId.validator.options[0]

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "kinoko7danmaku"
-version = "3.3.0"
+version = "3.3.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## 改动内容

- 修复启动报错
- 更新版本号到 3.3.2
- 删除多余代码

## 测试计划

- [ ] 验证启动是否正常
- [ ] 检查版本号是否正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 总结

修复启动错误，方法是更新语音ID验证器实现并清理冗余代码；将项目版本提升至 3.3.2。

Bug 修复:
- 通过修正语音ID验证器逻辑来解决启动异常。

改进:
- 重构 VoiceIdValidator 以继承 OptionsValidator，并通过 `super().__init__` 初始化其选项。
- 用新的 VoiceIdValidator 替换手动验证器分配，并调整选项存在性检查。

构建:
- 在 pyproject.toml 中将项目版本提升至 3.3.2。

杂项:
- 移除过时的代码注释和冗余的验证器设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix startup error by updating voice ID validator implementation and cleaning up redundant code; bump project version to 3.3.2.

Bug Fixes:
- Resolve startup exception by correcting the voice ID validator logic.

Enhancements:
- Refactor VoiceIdValidator to inherit from OptionsValidator and initialize its options via super().__init__.
- Replace manual validator assignment with the new VoiceIdValidator and adjust option existence check.

Build:
- Bump project version to 3.3.2 in pyproject.toml.

Chores:
- Remove obsolete code comments and redundant validator setup.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors voice ID validation to an OptionsValidator-based `VoiceIdValidator` and wires it into config initialization, plus bumps version to 3.3.2.
> 
> - **Core (qconfig)**:
>   - Replace `VoiceIdValidator` to extend `OptionsValidator`, initializing with `voiceDict` and validating/correcting against current keys.
>   - Update post-load setup: `cfg.minimaxVoiceId.validator = VoiceIdValidator(cfg.voiceDict)` and correct value via `options`; remove prior ad-hoc validator/options logic.
> - **Project**:
>   - Bump version to `3.3.2` (`pyproject.toml`, `uv.lock`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae78482db21e79ba2a4a1ff3185ae05f83ca391c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->