### PR TITLE
feat: 添加新模型支持 (v3.3.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kinoko7danmaku"
-version = "3.3.2"
+version = "3.3.3"
 requires-python = ">=3.12"
 dependencies = [
     "aiohttp>=3.12.14",

--- a/src/core/const.py
+++ b/src/core/const.py
@@ -17,6 +17,8 @@ SUPPORTED_SERVICES = {
 
 # MiniMax 支持的模型列表
 MINIMAX_MODELS = [
+    "speech-2.8-hd",
+    "speech-2.8-turbo",
     "speech-2.6-hd",
     "speech-2.6-turbo",
     "speech-02-hd",


### PR DESCRIPTION
## Summary
- 添加 MiniMax speech-2.8-hd 和 speech-2.8-turbo 模型支持
- 更新版本号到 3.3.3

## 由 Sourcery 提供的摘要

添加对更多 MiniMax 语音模型的支持，并提升项目版本号。

新功能：
- 支持 MiniMax `speech-2.8-hd` 模型。
- 支持 MiniMax `speech-2.8-turbo` 模型。

构建：
- 将项目版本从 `3.3.2` 提升到 `3.3.3`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for additional MiniMax speech models and bump the project version.

New Features:
- Support the MiniMax speech-2.8-hd model.
- Support the MiniMax speech-2.8-turbo model.

Build:
- Bump project version from 3.3.2 to 3.3.3.

</details>