### PR TITLE
feat: 数据目录迁移到用户目录 (v3.3.4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kinoko7danmaku"
-version = "3.3.3"
+version = "3.3.4"
 requires-python = ">=3.12"
 dependencies = [
     "aiohttp>=3.12.14",

--- a/src/core/const.py
+++ b/src/core/const.py
@@ -1,8 +1,40 @@
 """全局常量定义"""
 
+import shutil
 from pathlib import Path
 
 from models.service import ServiceDetail, ServiceType
+
+
+def get_data_dir() -> Path:
+    """获取数据存储目录
+
+    优先使用用户目录下的 ~/.kinoko7danmaku/，
+    如果根目录存在旧的 data/ 文件夹，则自动迁移数据。
+
+    Returns:
+        数据目录路径
+    """
+    user_data_dir = Path.home() / ".kinoko7danmaku"
+    legacy_data_dir = Path("data")
+
+    # 如果旧目录存在且用户目录不存在，进行迁移
+    if legacy_data_dir.exists() and not user_data_dir.exists():
+        user_data_dir.mkdir(parents=True, exist_ok=True)
+        for item in legacy_data_dir.iterdir():
+            dest = user_data_dir / item.name
+            if item.is_file():
+                shutil.copy2(item, dest)
+            elif item.is_dir():
+                shutil.copytree(item, dest)
+
+    # 确保用户数据目录存在
+    user_data_dir.mkdir(parents=True, exist_ok=True)
+    return user_data_dir
+
+
+# 数据目录
+DATA_DIR = get_data_dir()
 
 # 支持的 TTS 服务配置
 SUPPORTED_SERVICES = {
@@ -58,7 +90,7 @@ MINIMAX_VOICE_IDS = {
 }
 
 
-COOKIES_PATH = Path("data") / "cookies.json"
+COOKIES_PATH = DATA_DIR / "cookies.json"
 
 GITHUB_URL = "https://github.com/MerlinCN/kinoko7danmaku"
 

--- a/src/core/qconfig.py
+++ b/src/core/qconfig.py
@@ -19,6 +19,7 @@ from qfluentwidgets import (
 from models.service import ServiceType
 
 from .const import (
+    DATA_DIR,
     GPT_SOVITS_LANGUAGES,
     GPT_SOVITS_TEXT_SPLIT_METHODS,
     MINIMAX_ERROR_VOICE_ID,
@@ -552,7 +553,7 @@ class Config(QConfig):
 cfg = Config()
 
 # 加载配置文件
-qconfig.load("data/config.json", cfg)
+qconfig.load(str(DATA_DIR / "config.json"), cfg)
 
 cfg.minimaxVoiceId.validator = VoiceIdValidator(cfg.voiceDict)
 if cfg.minimaxVoiceId.value not in cfg.minimaxVoiceId.options:

--- a/src/core/update_checker.py
+++ b/src/core/update_checker.py
@@ -3,12 +3,12 @@
 import json
 import re
 import time
-from pathlib import Path
 from typing import NamedTuple
 
 import httpx
 from loguru import logger
 
+from core.const import DATA_DIR
 from core.version import __version__
 
 
@@ -26,7 +26,7 @@ class UpdateChecker:
 
     GITHUB_REPO = "MerlinCN/kinoko7danmaku"
     API_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
-    CACHE_FILE = Path("data/update_cache.json")
+    CACHE_FILE = DATA_DIR / "update_cache.json"
     CHECK_INTERVAL = 3600 * 1  # 1 小时检查一次
 
     @staticmethod

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "kinoko7danmaku"
-version = "3.3.2"
+version = "3.3.3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- 数据存储目录从 `./data/` 迁移到用户目录 `~/.kinoko7danmaku/`
- 自动兼容并迁移旧的 `data/` 目录数据
- 更新版本号到 3.3.4

## Summary by Sourcery

将应用程序数据存储从项目相对的 data 目录迁移到按用户划分的数据目录，并更新项目版本。

新功能：
- 引入用户专属数据目录 `~/.kinoko7danmaku`，用于存储应用数据、配置和缓存文件。
- 在首次运行时自动检测并将现有数据从旧版的 `./data` 目录迁移到新的用户数据目录中。

增强：
- 通过共享的 `DATA_DIR` 常量集中管理数据路径，在配置、cookies 和更新缓存文件中统一使用。

构建：
- 将项目版本从 `3.3.3` 提升到 `3.3.4`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate application data storage from the project-relative data directory to a per-user data directory and update the project version.

New Features:
- Introduce a user-specific data directory at ~/.kinoko7danmaku for storing application data, configuration, and cache files.
- Automatically detect and migrate existing data from the legacy ./data directory into the new user data directory on first run.

Enhancements:
- Centralize data path handling via a shared DATA_DIR constant used across configuration, cookies, and update cache files.

Build:
- Bump project version from 3.3.3 to 3.3.4.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves runtime data from `./data/` to `~/.kinoko7danmaku/` with automatic one-time migration of existing files.
> 
> - Adds `get_data_dir()` in `core/const.py` and defines `DATA_DIR`; copies legacy `data/` contents to user dir if present
> - Updates paths to use `DATA_DIR`: `COOKIES_PATH`, `qconfig.load(.../config.json)`, and `UpdateChecker.CACHE_FILE`
> - Bumps version to `3.3.4`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30f59e5c3ab18aa9f2945b225b983caf770579ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->