### PR TITLE
v3.6.0：新增醒目留言阈值，重构音色字典归属

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kinoko7danmaku"
-version = "3.5.0"
+version = "3.6.0"
 requires-python = ">=3.12"
 dependencies = [
     "aiohttp>=3.12.14",

--- a/src/bilibili/bili_service.py
+++ b/src/bilibili/bili_service.py
@@ -113,6 +113,8 @@ class BiliService(QObject):
             if not cfg.superChatOn.value:
                 return
             super_chat_message = SuperChatMessage.parse(event)
+            if super_chat_message.price < cfg.superChatThreshold.value:
+                return
             logger.info(super_chat_message)
 
             # 发射信号到 GUI

--- a/src/core/const.py
+++ b/src/core/const.py
@@ -82,13 +82,6 @@ GPT_SOVITS_TEXT_SPLIT_METHODS = [
 
 MINIMAX_ERROR_VOICE_ID = "未获取到音色列表，请检查API 密钥，然后刷新"
 
-MINIMAX_VOICE_IDS = {
-    "kinoko7_v1": "kinoko7_v1",
-    "moss_audio_05599258-a2c0-11f0-abb1-3ebcbb261618": "Isabel",
-    "moss_audio_6d40e743-357b-11f0-b24c-2e48b7cbf811": "Merlin",
-    "moss_audio_638d754a-357e-11f0-9505-4e9b7ef777f4": "芋艿",
-}
-
 
 COOKIES_PATH = DATA_DIR / "cookies.json"
 

--- a/src/core/qconfig.py
+++ b/src/core/qconfig.py
@@ -1,6 +1,8 @@
 """基于 qfluentwidgets 的配置管理"""
 
+import json
 from enum import StrEnum
+from pathlib import Path
 from typing import override
 
 import httpx
@@ -24,7 +26,6 @@ from .const import (
     GPT_SOVITS_TEXT_SPLIT_METHODS,
     MINIMAX_ERROR_VOICE_ID,
     MINIMAX_MODELS,
-    MINIMAX_VOICE_IDS,
     SUPPORTED_SERVICES,
 )
 from .player import audio_player
@@ -51,6 +52,7 @@ class ConfigKey(StrEnum):
     NORMAL_DANMAKU_ON = "NormalDanmakuOn"
     GUARD_ON = "GuardOn"
     SUPER_CHAT_ON = "SuperChatOn"
+    SUPER_CHAT_THRESHOLD = "SuperChatThreshold"
     WELCOME_ON = "WelcomeOn"
     DEBUG = "Debug"
     GIFT_ON_TEXT = "GiftOnText"
@@ -215,15 +217,14 @@ class VoiceIdValidator(OptionsValidator):
             value: 音色 ID
 
         Returns:
-            str: 有效的音色 ID
+            str: 有效的音色 ID；voiceDict 为空时返回 ""
         """
         available_voice_ids = list(self.voice_dict_config_item.value.keys())
         if value in available_voice_ids:
             return value
-        # 如果没有可用的音色 ID，使用默认的
         if available_voice_ids:
             return available_voice_ids[0]
-        return list(MINIMAX_VOICE_IDS.keys())[0]
+        return ""
 
 
 def get_voices(api_key: str) -> list[str]:
@@ -301,6 +302,13 @@ class Config(QConfig):
         validator=BoolValidator(),
     )
 
+    superChatThreshold = ConfigItem(
+        group=ConfigGroup.BILI_SERVICE,
+        name=ConfigKey.SUPER_CHAT_THRESHOLD,
+        default=30,
+        validator=IntValidator(),
+    )
+
     debug = ConfigItem(
         group=ConfigGroup.BILI_SERVICE,
         name=ConfigKey.DEBUG,
@@ -336,13 +344,6 @@ class Config(QConfig):
         group=ConfigGroup.BILI_SERVICE,
         name=ConfigKey.ALIAS_DICT,
         default={"Merlin": "么林"},
-        validator=DictValidator(),
-    )
-
-    voiceDict = ConfigItem(
-        group=ConfigGroup.BILI_SERVICE,
-        name=ConfigKey.VOICE_DICT,
-        default=MINIMAX_VOICE_IDS,
         validator=DictValidator(),
     )
 
@@ -388,6 +389,13 @@ class Config(QConfig):
         group=ConfigGroup.MINIMAX_SERVICE,
         name=ConfigKey.MINIMAX_API_KEY,
         default="",
+    )
+
+    voiceDict = ConfigItem(
+        group=ConfigGroup.MINIMAX_SERVICE,
+        name=ConfigKey.VOICE_DICT,
+        default={"kinoko7_v1": "kinoko7_v1"},
+        validator=DictValidator(),
     )
 
     minimaxModel = OptionsConfigItem(
@@ -549,6 +557,31 @@ class Config(QConfig):
     )
 
 
+def _migrate_voice_dict_to_minimax(config_path: Path) -> None:
+    """把旧 BiliService.VoiceDict 物理迁到 MinimaxService.VoiceDict
+
+    幂等：迁移后从 BiliService 删除 VoiceDict 字段并写回；若 MinimaxService 已有
+    VoiceDict，保留新值仅清理旧字段。
+    """
+    if not config_path.exists():
+        return
+    try:
+        raw = json.loads(config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return
+    bili = raw.get("BiliService", {})
+    if "VoiceDict" not in bili:
+        return
+    minimax = raw.setdefault("MinimaxService", {})
+    minimax.setdefault("VoiceDict", bili.pop("VoiceDict"))
+    config_path.write_text(
+        json.dumps(raw, ensure_ascii=False, indent=4),
+        encoding="utf-8",
+    )
+
+
+_migrate_voice_dict_to_minimax(DATA_DIR / "config.json")
+
 # 创建全局配置实例
 cfg = Config()
 
@@ -557,4 +590,6 @@ qconfig.load(str(DATA_DIR / "config.json"), cfg)
 
 cfg.minimaxVoiceId.validator = VoiceIdValidator(cfg.voiceDict)
 if cfg.minimaxVoiceId.value not in cfg.minimaxVoiceId.options:
-    cfg.minimaxVoiceId.value = cfg.minimaxVoiceId.options[0]
+    cfg.minimaxVoiceId.value = (
+        cfg.minimaxVoiceId.options[0] if cfg.minimaxVoiceId.options else ""
+    )

--- a/src/gui/view/settings.py
+++ b/src/gui/view/settings.py
@@ -107,13 +107,33 @@ class SettingsInterface(ScrollArea):
             parent=self.biliGroup,
         )
 
+        # 醒目留言设置卡片（可展开）
+        self.superChatSettingCard = ExpandGroupSettingCard(
+            icon=FIF.MESSAGE,
+            title="醒目留言设置",
+            content="配置醒目留言播报的相关参数",
+            parent=self.biliGroup,
+        )
+
         self.superChatCard = SwitchSettingCard(
             icon=FIF.MESSAGE,
             title="醒目留言",
             content="是否播报醒目留言",
             configItem=cfg.superChatOn,
-            parent=self.biliGroup,
+            parent=self.superChatSettingCard,
         )
+
+        self.superChatThresholdCard = IntSettingCard(
+            configItem=cfg.superChatThreshold,
+            icon=FIF.MESSAGE,
+            title="醒目留言阈值（元）",
+            content="只播报价值大于等于此阈值的醒目留言",
+            parent=self.superChatSettingCard,
+        )
+
+        # 将子卡片添加到展开卡片中
+        self.superChatSettingCard.addGroupWidget(self.superChatCard)
+        self.superChatSettingCard.addGroupWidget(self.superChatThresholdCard)
 
         self.debugCard = SwitchSettingCard(
             icon=FIF.CODE,
@@ -561,7 +581,7 @@ class SettingsInterface(ScrollArea):
         self.biliGroup.addSettingCard(self.freeGiftOnCard)
         self.biliGroup.addSettingCard(self.normalDanmakuCard)
         self.biliGroup.addSettingCard(self.guardCard)
-        self.biliGroup.addSettingCard(self.superChatCard)
+        self.biliGroup.addSettingCard(self.superChatSettingCard)
         self.biliGroup.addSettingCard(self.debugCard)
         self.biliGroup.addSettingCard(self.giftOnTextCard)
         self.biliGroup.addSettingCard(self.danmakuOnTextCard)

--- a/uv.lock
+++ b/uv.lock
@@ -530,7 +530,7 @@ wheels = [
 
 [[package]]
 name = "kinoko7danmaku"
-version = "3.4.0"
+version = "3.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- 新增醒目留言金额阈值配置（默认 30 元），bili_service 在 SC 事件中过滤低于阈值的消息
- 设置页将醒目留言开关与阈值收纳进 ExpandGroupSettingCard，参照礼物合并设置的样式
- voiceDict 从 BiliService 分组迁到 MinimaxService 分组，启动时物理改写旧 config.json 完成迁移
- 移除 MINIMAX_VOICE_IDS 硬编码常量，voiceDict 默认仅保留 kinoko7_v1 一个占位
- VoiceIdValidator 在 voiceDict 为空时返回空字符串作为兜底

## Test plan

- [ ] 启动 `uv run src/main.py`，旧 BiliService.VoiceDict 自动迁到 MinimaxService.VoiceDict 并清理旧字段
- [ ] 设置页醒目留言可展开卡内显示开关 + 阈值；阈值默认 30 持久化
- [ ] mock SC 事件：price < threshold 不播报；price >= threshold 播报
- [ ] 全新用户启动后 voiceDict 仅有 kinoko7_v1 一项，下拉一致

## Summary by Sourcery

为宣布 Super Chat 消息新增可配置阈值，并将语音配置迁移到 Minimax 服务组，同时增强语音 ID 校验和默认值的安全性。

新功能：
- 引入可配置的 Super Chat 金额阈值（默认 30），用来控制哪些 Super Chat 消息会被宣布。
- 在界面中新增可展开的 Super Chat 设置卡片，将启用开关和阈值配置归为一组。

改进：
- 将语音字典配置从 BiliService 组迁移到 MinimaxService 组，并在启动时自动迁移现有配置文件。
- 将默认的 Minimax 语音字典简化为单个占位语音，并调整语音 ID 校验逻辑，在没有可用语音时返回空的回退值。
- 当选项列表为空时，使 Minimax 语音 ID 的初始化更健壮。

构建：
- 将项目版本号从 3.5.0 提升到 3.6.0。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable threshold for announcing Super Chat messages and migrate voice configuration to the Minimax service group while hardening voice ID validation and defaults.

New Features:
- Introduce a configurable Super Chat amount threshold (default 30) to control which Super Chat messages are announced.
- Add an expandable Super Chat settings card in the UI that groups the enable switch and threshold configuration.

Enhancements:
- Move the voice dictionary configuration from the BiliService group to the MinimaxService group with an automatic on-start migration of existing config files.
- Simplify the default Minimax voice dictionary to a single placeholder voice and adjust voice ID validation to return an empty fallback when no voices are available.
- Make minimax voice ID initialization robust when the options list is empty.

Build:
- Bump project version from 3.5.0 to 3.6.0.

</details>