### PR TITLE
v3.6.1：修复启动后 VoiceId 被覆盖为默认音色

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kinoko7danmaku"
-version = "3.6.0"
+version = "3.6.1"
 requires-python = ">=3.12"
 dependencies = [
     "aiohttp>=3.12.14",

--- a/src/core/qconfig.py
+++ b/src/core/qconfig.py
@@ -178,12 +178,13 @@ class OutputDeviceValidator(OptionsValidator):
         return value if self.validate(value) else self.options[0]
 
 
-class VoiceIdValidator(OptionsValidator):
+class VoiceIdValidator(ConfigValidator):
     """音色 ID 验证器
 
-    动态从 voiceDict 获取可用的音色 ID 列表进行验证。
-    在加载配置时，如果用户在 voiceDict 中添加了自定义音色，
-    也能正确验证而不会被重置为默认值。
+    options/validate/correct 都从 voiceDict 实时读取，无任何缓存，
+    避免初始化时 voiceDict 还是 default 导致缓存的列表过时。
+    OptionsConfigItem.options 直接读 validator.options，因此 ComboBoxSettingCard
+    构造时也能拿到最新的音色列表。
     """
 
     def __init__(self, voice_dict_config_item):
@@ -193,38 +194,24 @@ class VoiceIdValidator(OptionsValidator):
             voice_dict_config_item: voiceDict 的 ConfigItem 实例
         """
         self.voice_dict_config_item = voice_dict_config_item
-        # 初始化父类，设置初始 options
-        super().__init__(list(voice_dict_config_item.value.keys()))
+
+    @property
+    def options(self) -> list[str]:
+        """实时返回 voiceDict 当前的音色 ID 列表"""
+        return list(self.voice_dict_config_item.value.keys())
 
     @override
     def validate(self, value) -> bool:
-        """验证音色 ID 是否在可用列表中
-
-        Args:
-            value: 音色 ID
-
-        Returns:
-            bool: 是否有效
-        """
-        available_voice_ids = list(self.voice_dict_config_item.value.keys())
-        return value in available_voice_ids
+        """验证音色 ID 是否在 voiceDict 中"""
+        return value in self.voice_dict_config_item.value
 
     @override
     def correct(self, value):
-        """修正音色 ID 为有效值
-
-        Args:
-            value: 音色 ID
-
-        Returns:
-            str: 有效的音色 ID；voiceDict 为空时返回 ""
-        """
-        available_voice_ids = list(self.voice_dict_config_item.value.keys())
-        if value in available_voice_ids:
+        """修正音色 ID；voiceDict 为空时返回 ""，否则返回第一个 key"""
+        if self.validate(value):
             return value
-        if available_voice_ids:
-            return available_voice_ids[0]
-        return ""
+        keys = list(self.voice_dict_config_item.value.keys())
+        return keys[0] if keys else ""
 
 
 def get_voices(api_key: str) -> list[str]:
@@ -585,11 +572,25 @@ _migrate_voice_dict_to_minimax(DATA_DIR / "config.json")
 # 创建全局配置实例
 cfg = Config()
 
+
+def _preload_voice_dict(config_path: Path) -> None:
+    """qconfig.load 按 json 字段顺序反序列化，若 VoiceId 出现在 VoiceDict 之前，
+    VoiceId 会被 VoiceIdValidator.correct 拿过期的（default）voiceDict 覆写成
+    kinoko7_v1。这里在 load 之前先把 VoiceDict 拉到 cfg，保证后续 VoiceId 校验
+    拿到完整的音色列表。
+    """
+    if not config_path.exists():
+        return
+    try:
+        raw = json.loads(config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return
+    saved = raw.get("MinimaxService", {}).get("VoiceDict")
+    if isinstance(saved, dict):
+        cfg.voiceDict.value = saved
+
+
+_preload_voice_dict(DATA_DIR / "config.json")
+
 # 加载配置文件
 qconfig.load(str(DATA_DIR / "config.json"), cfg)
-
-cfg.minimaxVoiceId.validator = VoiceIdValidator(cfg.voiceDict)
-if cfg.minimaxVoiceId.value not in cfg.minimaxVoiceId.options:
-    cfg.minimaxVoiceId.value = (
-        cfg.minimaxVoiceId.options[0] if cfg.minimaxVoiceId.options else ""
-    )

--- a/src/gui/view/settings.py
+++ b/src/gui/view/settings.py
@@ -510,7 +510,6 @@ class SettingsInterface(ScrollArea):
         toast.show()
         if not cfg.minimaxApiKey.value:
             voices = [MINIMAX_ERROR_VOICE_ID]
-            cfg.minimaxVoiceId.validator.options = voices
             cfg.minimaxVoiceId.value = MINIMAX_ERROR_VOICE_ID
             self._update_voice_options(voices, MINIMAX_ERROR_VOICE_ID)
             return
@@ -519,8 +518,6 @@ class SettingsInterface(ScrollArea):
         voices = await asyncio.to_thread(get_voices, cfg.minimaxApiKey.value)
         if not voices:
             voices = [MINIMAX_ERROR_VOICE_ID]
-
-        cfg.minimaxVoiceId.validator.options = voices
 
         # 如果当前值不在新列表中，使用第一个选项
         value = voices[0] if voices else MINIMAX_ERROR_VOICE_ID
@@ -546,11 +543,9 @@ class SettingsInterface(ScrollArea):
         if not voice_dict:
             return
 
-        # 获取音色 ID 列表（键）和显示名称列表（值）
         voice_ids = list(voice_dict.keys())
 
-        # 更新验证器的选项
-        cfg.minimaxVoiceId.validator.options = voice_ids
+        # validator.options 是 property 实时读取，不需手动同步
         # 如果当前值不在新列表中，使用第一个选项
         current_value = cfg.minimaxVoiceId.value
         if current_value not in voice_ids:

--- a/uv.lock
+++ b/uv.lock
@@ -530,7 +530,7 @@ wheels = [
 
 [[package]]
 name = "kinoko7danmaku"
-version = "3.6.0"
+version = "3.6.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- VoiceIdValidator.options 改为 property 实时读取 voiceDict，去除缓存导致的过时问题
- 新增 _preload_voice_dict 在 qconfig.load 之前预热 VoiceDict，规避字段加载顺序导致 VoiceId 被错误 correct 成 kinoko7_v1
- 删除 load 后 validator 重挂载与冗余兜底
- settings 中移除已无效的 validator.options 手动赋值

## Test plan

- [ ] 启动 `uv run src/main.py`，config.json 中 VoiceId=yommyko_v1 应保持不变
- [ ] 设置页 → MiniMax → 音色 ID 下拉应显示 voiceDict 的全部音色
- [ ] 在音色字典中新增/删除条目，下拉与 validator 同步

## 由 Sourcery 提供的摘要

确保 MiniMax 语音 ID 配置始终与动态语音字典保持同步，并且在启动时不再被覆盖。

错误修复：
- 防止在 voice 字典尚未填充时加载 `config.json`，`minimaxVoiceId` 被错误地重置为默认语音。
- 确保语音 ID 校验始终使用当前的 `voiceDict` 内容，而不是使用缓存的可选项列表。

增强功能：
- 让 VoiceId 校验器通过属性从语音字典中动态读取可用选项，使 UI 下拉框与配置的校验保持一致。
- 通过依赖校验器的动态选项，而不是手动同步选项列表，简化 MiniMax 设置逻辑。

构建：
- 将项目版本提升到 3.6.1。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure MiniMax voice ID configuration stays in sync with the dynamic voice dictionary and is no longer overwritten on startup.

Bug Fixes:
- Prevent minimaxVoiceId from being incorrectly reset to the default voice when loading config.json before the voice dictionary is populated.
- Ensure voice ID validation always uses the current voiceDict contents instead of a cached options list.

Enhancements:
- Make the VoiceId validator read available options dynamically from the voice dictionary via a property, keeping UI dropdowns and validation consistent with config.
- Simplify MiniMax settings logic by relying on the validator’s dynamic options instead of manually synchronizing option lists.

Build:
- Bump project version to 3.6.1.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

确保 MiniMax 语音 ID 配置始终与动态语音字典保持同步，并且在启动时不再被覆盖。

错误修复：
- 防止在 voice 字典尚未填充时加载 `config.json`，`minimaxVoiceId` 被错误地重置为默认语音。
- 确保语音 ID 校验始终使用当前的 `voiceDict` 内容，而不是使用缓存的可选项列表。

增强功能：
- 让 VoiceId 校验器通过属性从语音字典中动态读取可用选项，使 UI 下拉框与配置的校验保持一致。
- 通过依赖校验器的动态选项，而不是手动同步选项列表，简化 MiniMax 设置逻辑。

构建：
- 将项目版本提升到 3.6.1。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure MiniMax voice ID configuration stays in sync with the dynamic voice dictionary and is no longer overwritten on startup.

Bug Fixes:
- Prevent minimaxVoiceId from being incorrectly reset to the default voice when loading config.json before the voice dictionary is populated.
- Ensure voice ID validation always uses the current voiceDict contents instead of a cached options list.

Enhancements:
- Make the VoiceId validator read available options dynamically from the voice dictionary via a property, keeping UI dropdowns and validation consistent with config.
- Simplify MiniMax settings logic by relying on the validator’s dynamic options instead of manually synchronizing option lists.

Build:
- Bump project version to 3.6.1.

</details>

</details>