### PR TITLE
Add piper-tts service

### DIFF
--- a/src/core/const.py
+++ b/src/core/const.py
@@ -64,6 +64,9 @@ SUPPORTED_SERVICES = {
     ServiceType.FISH_SPEECH: ServiceDetail(
         name=ServiceType.FISH_SPEECH, description="Fish Speech"
     ),
+    ServiceType.PIPER: ServiceDetail(
+        name=ServiceType.PIPER, description="Piper"
+    ),
 }
 
 # MiniMax 支持的模型列表

--- a/src/core/qconfig.py
+++ b/src/core/qconfig.py
@@ -39,6 +39,7 @@ class ConfigGroup(StrEnum):
     MINIMAX_SERVICE = "MinimaxService"
     FISH_SPEECH_SERVICE = "FishSpeechService"
     GPT_SOVITS_SERVICE = "GptSovitsService"
+    PIPER_SERVICE = "PiperService"
     PLAYER = "Player"
 
 
@@ -96,6 +97,15 @@ class ConfigKey(StrEnum):
     GPT_SOVITS_SAMPLE_STEPS = "SampleSteps"
     GPT_SOVITS_SUPER_SAMPLING = "SuperSampling"
     GPT_SOVITS_PAUSE_SECONDS = "PauseSeconds"
+
+    # Piper 服务
+    PIPER_API_URL = "ApiUrl"
+    PIPER_VOICE = "Voice"
+    PIPER_SPEAKER = "Speaker"
+    PIPER_SPEAKER_ID = "SpeakerId"
+    PIPER_LENGTH_SCALE = "LengthScale"
+    PIPER_NOISE_SCALE = "NoiseScale"
+    PIPER_NOISE_W_SCALE = "NoiseWScale"
 
     # 播放器
     PLAYER_DEVICE = "PlayerDevice"
@@ -533,6 +543,53 @@ class Config(QConfig):
         name=ConfigKey.GPT_SOVITS_PAUSE_SECONDS,
         default=0.3,
         validator=RangeValidator(0.0, 5.0),
+    )
+
+    # Piper TTS 服务配置
+    piperApiUrl = ConfigItem(
+        group=ConfigGroup.PIPER_SERVICE,
+        name=ConfigKey.PIPER_API_URL,
+        default="http://localhost:5000",
+    )
+    
+    piperVoice = ConfigItem(
+        group=ConfigGroup.PIPER_SERVICE,
+        name=ConfigKey.PIPER_VOICE,
+        default="",
+    )
+
+    piperSpeaker = ConfigItem(
+        group=ConfigGroup.PIPER_SERVICE,
+        name=ConfigKey.PIPER_SPEAKER,
+        default="",
+    )
+
+    piperSpeakerId = ConfigItem(
+        group=ConfigGroup.PIPER_SERVICE,
+        name=ConfigKey.PIPER_SPEAKER_ID,
+        default=0,
+        validator=IntValidator(),
+    )
+
+    piperLengthScale = RangeConfigItem(
+        group=ConfigGroup.PIPER_SERVICE,
+        name=ConfigKey.PIPER_LENGTH_SCALE,
+        default=1.0,
+        validator=RangeValidator(0.0, 3.0),
+    )
+
+    piperNoiseScale = RangeConfigItem(
+        group=ConfigGroup.PIPER_SERVICE,
+        name=ConfigKey.PIPER_NOISE_SCALE,
+        default=0.667,
+        validator=RangeValidator(0.0, 1.0),
+    )
+
+    piperNoiseWScale = RangeConfigItem(
+        group=ConfigGroup.PIPER_SERVICE,
+        name=ConfigKey.PIPER_NOISE_W_SCALE,
+        default=0.8,
+        validator=RangeValidator(0.0, 1.0),
     )
 
     # 播放器配置

--- a/src/gui/view/settings.py
+++ b/src/gui/view/settings.py
@@ -480,6 +480,74 @@ class SettingsInterface(ScrollArea):
             parent=self.gptSovitsGroup,
         )
 
+        # Piper 服务设置组
+        self.piperGroup = SettingCardGroup("Piper 设置", self.scrollWidget)
+
+        self.piperApiUrlCard = StrSettingCard(
+            configItem=cfg.piperApiUrl,
+            icon=FIF.LINK,
+            title="API 地址",
+            content="设置 Piper TTS 服务的 API 地址",
+            parent=self.piperGroup,
+            placeholder="http://localhost:5000",
+        )
+
+        self.piperVoiceCard = StrSettingCard(
+            configItem=cfg.piperVoice,
+            icon=FIF.TAG,
+            title="语音模型",
+            content="设置 Piper TTS 使用的语音模型",
+            parent=self.piperGroup,
+            placeholder="语音模型名称",
+        )
+
+        self.piperSpeakerCard = StrSettingCard(
+            configItem=cfg.piperSpeaker,
+            icon=FIF.TAG,
+            title="说话者",
+            content="设置多说话者模型的说话者",
+            parent=self.piperGroup,
+            placeholder="说话者名称",
+        )
+
+        self.piperSpeakerIdCard = IntSettingCard(
+            configItem=cfg.piperSpeakerId,
+            icon=FIF.TAG,
+            title="说话者ID",
+            content="设置多说话者模型的说话者ID（会覆盖名称设置）",
+            parent=self.piperGroup,
+        )
+
+        self.piperLengthScaleCard = FloatRangeSettingCard(
+            configItem=cfg.piperLengthScale,
+            icon=FIF.TAG,
+            title="模型语速",
+            content="设置模型的说话语速（持续时间系数, 值越大越慢）",
+            step=0.1,
+            decimals=1,
+            parent=self.piperGroup,
+        )
+
+        self.piperNoiseScaleCard = FloatRangeSettingCard(
+            configItem=cfg.piperNoiseScale,
+            icon=FIF.TAG,
+            title="模型噪声比例",
+            content="设置模型的噪声比例（语音变化程度）",
+            step=0.001,
+            decimals=3,
+            parent=self.piperGroup,
+        )
+
+        self.piperNoiseWScaleCard = FloatRangeSettingCard(
+            configItem=cfg.piperNoiseWScale,
+            icon=FIF.TAG,
+            title="模型噪声宽度",
+            content="设置模型的噪声宽度（音素时长变化程度）",
+            step=0.01,
+            decimals=2,
+            parent=self.piperGroup,
+        )
+
         # 播放器设置组
         self.playerGroup = SettingCardGroup("音频设置", self.scrollWidget)
 
@@ -618,6 +686,15 @@ class SettingsInterface(ScrollArea):
         self.gptSovitsGroup.addSettingCard(self.gptSovitsSampleStepsCard)
         self.gptSovitsGroup.addSettingCard(self.gptSovitsSuperSamplingCard)
         self.gptSovitsGroup.addSettingCard(self.gptSovitsPauseSecondsCard)
+        
+        # 添加 Piper 服务设置卡片
+        self.piperGroup.addSettingCard(self.piperApiUrlCard)
+        self.piperGroup.addSettingCard(self.piperVoiceCard)
+        self.piperGroup.addSettingCard(self.piperSpeakerCard)
+        self.piperGroup.addSettingCard(self.piperSpeakerIdCard)
+        self.piperGroup.addSettingCard(self.piperLengthScaleCard)
+        self.piperGroup.addSettingCard(self.piperNoiseScaleCard)
+        self.piperGroup.addSettingCard(self.piperNoiseWScaleCard)
 
         # 添加播放器设置卡片
         self.playerGroup.addSettingCard(self.playerDeviceCard)
@@ -632,6 +709,7 @@ class SettingsInterface(ScrollArea):
         self.expandLayout.addWidget(self.minimaxGroup)
         self.expandLayout.addWidget(self.fishSpeechGroup)
         self.expandLayout.addWidget(self.gptSovitsGroup)
+        self.expandLayout.addWidget(self.piperGroup)
 
         # 设置滚动区域
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)

--- a/src/gui/view/settings.py
+++ b/src/gui/view/settings.py
@@ -494,7 +494,7 @@ class SettingsInterface(ScrollArea):
 
         self.piperVoiceCard = StrSettingCard(
             configItem=cfg.piperVoice,
-            icon=FIF.TAG,
+            icon=FIF.ROBOT,
             title="语音模型",
             content="设置 Piper TTS 使用的语音模型",
             parent=self.piperGroup,
@@ -503,7 +503,7 @@ class SettingsInterface(ScrollArea):
 
         self.piperSpeakerCard = StrSettingCard(
             configItem=cfg.piperSpeaker,
-            icon=FIF.TAG,
+            icon=FIF.CHAT,
             title="说话者",
             content="设置多说话者模型的说话者",
             parent=self.piperGroup,
@@ -520,7 +520,7 @@ class SettingsInterface(ScrollArea):
 
         self.piperLengthScaleCard = FloatRangeSettingCard(
             configItem=cfg.piperLengthScale,
-            icon=FIF.TAG,
+            icon=FIF.SPEED_OFF,
             title="模型语速",
             content="设置模型的说话语速（持续时间系数, 值越大越慢）",
             step=0.1,
@@ -530,7 +530,7 @@ class SettingsInterface(ScrollArea):
 
         self.piperNoiseScaleCard = FloatRangeSettingCard(
             configItem=cfg.piperNoiseScale,
-            icon=FIF.TAG,
+            icon=FIF.PALETTE,
             title="模型噪声比例",
             content="设置模型的噪声比例（语音变化程度）",
             step=0.001,
@@ -540,7 +540,7 @@ class SettingsInterface(ScrollArea):
 
         self.piperNoiseWScaleCard = FloatRangeSettingCard(
             configItem=cfg.piperNoiseWScale,
-            icon=FIF.TAG,
+            icon=FIF.PALETTE,
             title="模型噪声宽度",
             content="设置模型的噪声宽度（音素时长变化程度）",
             step=0.01,

--- a/src/models/service.py
+++ b/src/models/service.py
@@ -11,6 +11,7 @@ class ServiceType(str, Enum):
     FISH_SPEECH = "fish_speech"
     GPT_SOVITS = "gpt_sovits"
     MINIMAX = "minimax"
+    PIPER = "piper"
 
 
 class ServiceDetail(BaseModel):

--- a/src/tts_service/__init__.py
+++ b/src/tts_service/__init__.py
@@ -5,11 +5,12 @@ from .base import TTSService
 from .fish_speech import FishSpeechService
 from .gpt_sovits import GPTSovitsService
 from .minimax import MinimaxService
+from .piper import PiperService
 
 _default_tts_service = None
 
 
-def get_tts_service() -> FishSpeechService | GPTSovitsService | MinimaxService:
+def get_tts_service() -> FishSpeechService | GPTSovitsService | MinimaxService | PiperService:
     """获取TTS服务"""
 
     global _default_tts_service
@@ -24,6 +25,10 @@ def get_tts_service() -> FishSpeechService | GPTSovitsService | MinimaxService:
 
     elif model_type == ServiceType.MINIMAX:
         _default_tts_service = MinimaxService()
+    
+    elif model_type == ServiceType.PIPER:
+        _default_tts_service = PiperService()
+
     else:
         raise ValueError(f"Invalid TTS service: {model_type}")
     return _default_tts_service
@@ -34,5 +39,6 @@ __all__ = [
     "FishSpeechService",
     "GPTSovitsService",
     "MinimaxService",
+    "PiperService",
     "get_tts_service",
 ]

--- a/src/tts_service/piper.py
+++ b/src/tts_service/piper.py
@@ -1,0 +1,76 @@
+import httpx
+from loguru import logger
+
+from core.qconfig import cfg
+
+from .base import TTSService
+
+
+class PiperService(TTSService):
+    """Piper TTS 适配器"""
+
+    def __init__(self) -> None:
+        """初始化 Piper 适配器"""
+        self.api_url = cfg.piperApiUrl.value
+
+    async def text_to_speech(
+        self,
+        text: str,
+        voice: str | None = None,
+        speaker: str | None = None,
+        speaker_id: int | None = None,
+        length_scale: float | None = None,
+        noise_scale: float | None = None,
+        noise_w_scale: float | None = None,
+    ) -> bytes:
+        """
+        使用piper-tts API将文本转换为语音
+
+        Args:
+            text: 要转换的文本
+            voice: 使用的语音模型
+            speaker: 多说话人语音模型的说话人名称
+            speaker_id: 多说话人语音的说话人ID, 会覆盖 speaker 参数
+            length_scale: 语速
+            noise_scale: 模型语音变化程度
+            noise_w_scale: 模型音素时长变化程度
+
+        Returns:
+            bytes: 音频数据（WAV格式）
+
+        Raises:
+            httpx.HTTPStatusError: HTTP请求失败
+        """
+        if voice is None:
+            voice = cfg.piperVoice.value
+        if speaker is None:
+            speaker = cfg.piperSpeaker.value
+        if speaker_id is None:
+            speaker_id = cfg.piperSpeakerId.value
+        if length_scale is None:
+            length_scale = cfg.piperLengthScale.value
+        if noise_scale is None:
+            noise_scale = cfg.piperNoiseScale.value
+        if noise_w_scale is None:
+            noise_w_scale = cfg.piperNoiseWScale.value
+
+        # 准备请求数据, 过滤值为 None 或为空 的参数
+        data = {
+            k: v for k, v in {
+                "text": text,
+                "voice": voice,
+                "speaker": speaker,
+                "speaker_id": speaker_id,
+                "length_scale": length_scale,
+                "noise_scale": noise_scale,
+                "noise_w_scale": noise_w_scale
+            }.items() if v 
+        }
+
+        async with httpx.AsyncClient() as client:
+            logger.debug(f"Piper 请求 data 为: {data}")
+            response = await client.post(self.api_url, json=data, timeout=300)
+            response.raise_for_status()
+            logger.info(f"Piper TTS 成功: {text}")
+
+        return response.content


### PR DESCRIPTION
## Summary by Sourcery

添加基于 Piper 的 TTS 服务，并在设置中暴露其配置。

New Features:
- 引入 Piper TTS 服务适配器，通过调用 `piper-tts` 的 HTTP API 来合成语音。
- 在服务模型和服务注册表中添加新的 Piper 服务类型，可与现有的 TTS 提供方一起进行选择。
- 在 GUI 设置面板中暴露 Piper TTS 的配置选项（API URL、voice、speaker、speaker ID 以及合成参数）。

Enhancements:
- 扩展配置模式，加入 Piper 专用选项，包括用于语音合成的 length、noise 和 speaker 控制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Piper-based TTS service and expose its configuration in settings.

New Features:
- Introduce a Piper TTS service adapter that calls a piper-tts HTTP API to synthesize speech.
- Add a new Piper service type to the service model and service registry for selection alongside existing TTS providers.
- Expose Piper TTS configuration options (API URL, voice, speaker, speaker ID, and synthesis parameters) in the GUI settings panel.

Enhancements:
- Extend configuration schema with Piper-specific options including length, noise, and speaker controls for TTS synthesis.

</details>