### PR TITLE
feat: add edge-tts service

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ requires-python = ">=3.12"
 dependencies = [
     "aiohttp>=3.12.14",
     "bilibili-api-python>=17.3.0",
+    "edge-tts>=7.2.8",
     "faker>=37.12.0",
     "httpx[socks]>=0.28.1",
     "loguru>=0.7.3",
@@ -16,6 +17,7 @@ dependencies = [
     "pyside6-fluent-widgets[full]>=1.9.1",
     "qasync>=0.28.0",
     "qrcode>=8.2",
+    "requests>=2.34.2",
     "sounddevice>=0.5.2",
     "stream-gears>=0.2.4",
     "tenacity>=9.1.2",

--- a/src/core/const.py
+++ b/src/core/const.py
@@ -67,6 +67,9 @@ SUPPORTED_SERVICES = {
     ServiceType.PIPER: ServiceDetail(
         name=ServiceType.PIPER, description="Piper"
     ),
+    ServiceType.EDGE: ServiceDetail(
+        name=ServiceType.EDGE, description="Edge"
+    )
 }
 
 # MiniMax 支持的模型列表
@@ -104,6 +107,23 @@ GPT_SOVITS_TEXT_SPLIT_METHODS = [
 
 MINIMAX_ERROR_VOICE_ID = "未获取到音色列表，请检查API 密钥，然后刷新"
 
+# Edge TTS 语音选项
+EDGE_VOICES = [
+    "zh-CN-XiaoxiaoNeural",
+    "zh-CN-XiaoyiNeural",
+    "zh-CN-YunjianNeural",
+    "zh-CN-YunxiNeural",
+    "zh-CN-YunxiaNeural",
+    "zh-CN-YunyangNeural",
+    "zh-CN-liaoning-XiaobeiNeural",
+    "zh-CN-shaanxi-XiaoniNeural",
+    "zh-HK-HiuGaaiNeural",
+    "zh-HK-HiuMaanNeural",
+    "zh-HK-WanLungNeural",
+    "zh-TW-HsiaoChenNeural",
+    "zh-TW-HsiaoYuNeural",
+    "zh-TW-YunJheNeural",
+]
 
 COOKIES_PATH = DATA_DIR / "cookies.json"
 

--- a/src/core/qconfig.py
+++ b/src/core/qconfig.py
@@ -26,6 +26,7 @@ from .const import (
     GPT_SOVITS_TEXT_SPLIT_METHODS,
     MINIMAX_ERROR_VOICE_ID,
     MINIMAX_MODELS,
+    EDGE_VOICES,
     SUPPORTED_SERVICES,
 )
 from .player import audio_player
@@ -40,6 +41,7 @@ class ConfigGroup(StrEnum):
     FISH_SPEECH_SERVICE = "FishSpeechService"
     GPT_SOVITS_SERVICE = "GptSovitsService"
     PIPER_SERVICE = "PiperService"
+    EDGE_SERVICE = "EdgeService"
     PLAYER = "Player"
 
 
@@ -106,6 +108,12 @@ class ConfigKey(StrEnum):
     PIPER_LENGTH_SCALE = "LengthScale"
     PIPER_NOISE_SCALE = "NoiseScale"
     PIPER_NOISE_W_SCALE = "NoiseWScale"
+
+    # Edge 服务
+    EDGE_VOICE  = "Voice"
+    EDGE_RATE = "Rate"
+    EDGE_VOLUME = "Volume"
+    EDGE_PITCH = "Pitch"
 
     # 播放器
     PLAYER_DEVICE = "PlayerDevice"
@@ -590,6 +598,35 @@ class Config(QConfig):
         name=ConfigKey.PIPER_NOISE_W_SCALE,
         default=0.8,
         validator=RangeValidator(0.0, 1.0),
+    )
+
+    # Edge TTS 服务配置
+    edgeVoice = OptionsConfigItem(
+        group=ConfigGroup.EDGE_SERVICE,
+        name=ConfigKey.EDGE_VOICE,
+        default="zh-CN-XiaoxiaoNeural",
+        validator=OptionsValidator(EDGE_VOICES)
+    )
+
+    edgeRate = RangeConfigItem(
+        group=ConfigGroup.EDGE_SERVICE,
+        name=ConfigKey.EDGE_RATE,
+        default=1.0,
+        validator=RangeValidator(0.0, 3.0),
+    )     
+    
+    edgeVolume = RangeConfigItem(
+        group=ConfigGroup.EDGE_SERVICE,
+        name=ConfigKey.EDGE_VOLUME,
+        default=1.0,
+        validator=RangeValidator(0.0, 3.0),
+    )   
+
+    edgePitch = RangeConfigItem(
+        group=ConfigGroup.EDGE_SERVICE,
+        name=ConfigKey.EDGE_PITCH,
+        default=0,
+        validator=RangeValidator(-300, 300),
     )
 
     # 播放器配置

--- a/src/gui/view/settings.py
+++ b/src/gui/view/settings.py
@@ -9,6 +9,7 @@ from qfluentwidgets import (
     ComboBoxSettingCard,
     ExpandGroupSettingCard,
     ExpandLayout,
+    RangeSettingCard,
     ScrollArea,
     SettingCardGroup,
     StateToolTip,
@@ -26,6 +27,7 @@ from core.const import (
     GPT_SOVITS_TEXT_SPLIT_METHODS,
     MINIMAX_ERROR_VOICE_ID,
     MINIMAX_MODELS,
+    EDGE_VOICES,
     SUPPORTED_SERVICES,
 )
 from core.player import audio_player
@@ -548,6 +550,46 @@ class SettingsInterface(ScrollArea):
             parent=self.piperGroup,
         )
 
+        # Edge 服务设置组
+        self.edgeGroup = SettingCardGroup("Edge TTS 设置", self.scrollWidget)
+
+        self.edgeVoiceCard = ComboBoxSettingCard(
+            configItem=cfg.edgeVoice,
+            icon=FIF.TAG,
+            title="语音模型",
+            content="设置 Edge TTS 的语音模型",
+            texts=EDGE_VOICES,
+            parent=self.edgeGroup,
+        )
+
+        self.edgeRateCard = FloatRangeSettingCard(
+            configItem=cfg.edgeRate,
+            icon=FIF.SPEED_OFF,
+            title="语音速率",
+            content="设置 Edge TTS 的语音速率",
+            step=0.05,
+            decimals=2,
+            parent=self.edgeGroup,
+        )
+
+        self.edgeVolumeCard = FloatRangeSettingCard(
+            configItem=cfg.edgeVolume,
+            icon=FIF.VOLUME,
+            title="语音音量",
+            content="设置 Edge TTS 的语音音量",
+            step=0.05,
+            decimals=2,
+            parent=self.edgeGroup,
+        )
+
+        self.edgePitchCard = RangeSettingCard(
+            configItem=cfg.edgePitch,
+            icon=FIF.MUSIC,
+            title="语音音调",
+            content="设置 Edge TTS 的语音音调",
+            parent=self.edgeGroup,
+        )
+
         # 播放器设置组
         self.playerGroup = SettingCardGroup("音频设置", self.scrollWidget)
 
@@ -695,6 +737,12 @@ class SettingsInterface(ScrollArea):
         self.piperGroup.addSettingCard(self.piperLengthScaleCard)
         self.piperGroup.addSettingCard(self.piperNoiseScaleCard)
         self.piperGroup.addSettingCard(self.piperNoiseWScaleCard)
+        
+        # 添加 Edge 服务设置卡片
+        self.edgeGroup.addSettingCard(self.edgeVoiceCard)
+        self.edgeGroup.addSettingCard(self.edgeRateCard)
+        self.edgeGroup.addSettingCard(self.edgeVolumeCard)
+        self.edgeGroup.addSettingCard(self.edgePitchCard)
 
         # 添加播放器设置卡片
         self.playerGroup.addSettingCard(self.playerDeviceCard)
@@ -710,6 +758,7 @@ class SettingsInterface(ScrollArea):
         self.expandLayout.addWidget(self.fishSpeechGroup)
         self.expandLayout.addWidget(self.gptSovitsGroup)
         self.expandLayout.addWidget(self.piperGroup)
+        self.expandLayout.addWidget(self.edgeGroup)
 
         # 设置滚动区域
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)

--- a/src/models/service.py
+++ b/src/models/service.py
@@ -12,6 +12,7 @@ class ServiceType(str, Enum):
     GPT_SOVITS = "gpt_sovits"
     MINIMAX = "minimax"
     PIPER = "piper"
+    EDGE = "edge"
 
 
 class ServiceDetail(BaseModel):

--- a/src/tts_service/__init__.py
+++ b/src/tts_service/__init__.py
@@ -6,11 +6,12 @@ from .fish_speech import FishSpeechService
 from .gpt_sovits import GPTSovitsService
 from .minimax import MinimaxService
 from .piper import PiperService
+from .edge import EdgeService
 
 _default_tts_service = None
 
 
-def get_tts_service() -> FishSpeechService | GPTSovitsService | MinimaxService | PiperService:
+def get_tts_service() -> FishSpeechService | GPTSovitsService | MinimaxService | PiperService | EdgeService:
     """获取TTS服务"""
 
     global _default_tts_service
@@ -29,6 +30,9 @@ def get_tts_service() -> FishSpeechService | GPTSovitsService | MinimaxService |
     elif model_type == ServiceType.PIPER:
         _default_tts_service = PiperService()
 
+    elif model_type == ServiceType.EDGE:
+        _default_tts_service = EdgeService()
+
     else:
         raise ValueError(f"Invalid TTS service: {model_type}")
     return _default_tts_service
@@ -40,5 +44,6 @@ __all__ = [
     "GPTSovitsService",
     "MinimaxService",
     "PiperService",
+    "EdgeService",
     "get_tts_service",
 ]

--- a/src/tts_service/edge.py
+++ b/src/tts_service/edge.py
@@ -16,13 +16,13 @@ class EdgeService(TTSService):
     async def text_to_speech(
         self,
         text: str,
-        voice: str = "zh-CN-XiaoxiaoNeural",
-        rate: str = "+0%",
-        volume: str = "+0%", 
-        pitch: str = "+0Hz",
+        voice: str | None = None,
+        rate: str | None = None,
+        volume: str | None = None, 
+        pitch: str | None = None,
     ) -> bytes:
         """
-        使用 edge-tts 将文本转换为语音
+        使用 Edge TTS 将文本转换为语音
 
         Args:
             text: 要转换的文本
@@ -54,7 +54,7 @@ class EdgeService(TTSService):
                 rate=rate,
                 volume=volume,
                 pitch=pitch)
-        
+
         async for chunk in communicate.stream():
             if chunk["type"] == "audio":
                 audio_data.write(chunk["data"])

--- a/src/tts_service/edge.py
+++ b/src/tts_service/edge.py
@@ -1,0 +1,73 @@
+from io import BytesIO
+from loguru import logger
+import edge_tts
+
+from core.qconfig import cfg
+
+from .base import TTSService
+
+class EdgeService(TTSService):
+    """Edge TTS 适配器"""
+
+    def __init__(self) -> None:
+        """初始化 Edge 适配器"""
+        pass
+
+    async def text_to_speech(
+        self,
+        text: str,
+        voice: str = "zh-CN-XiaoxiaoNeural",
+        rate: str = "+0%",
+        volume: str = "+0%", 
+        pitch: str = "+0Hz",
+    ) -> bytes:
+        """
+        使用 edge-tts 将文本转换为语音
+
+        Args:
+            text: 要转换的文本
+            voice: 使用的语音模型
+            rate: 语音速率
+            volume: 语音音量
+            pitch: 语音音调
+
+        Returns:
+            bytes: 音频数据（MP3格式）
+
+        Raises:
+            NoAudioReceived: 如果未从服务接收到音频。
+            UnexpectedResponse: 如果从服务收到意外的响应。
+            UnknownResponse: 如果从服务收到未知的响应。
+            WebSocketError: 如果websocket出现错误。
+        """
+        # 获取参数，并格式化参数为字符串
+        voice = cfg.edgeVoice.value
+        rate = f"{int((cfg.edgeRate.value - 1.0) * 100):+d}%"
+        volume = f"{int((cfg.edgeVolume.value - 1.0) * 100):+d}%"
+        pitch = f"{cfg.edgePitch.value:+d}Hz"
+
+        # 发起请求
+        audio_data = BytesIO()
+        communicate = edge_tts.Communicate(
+                text=text,
+                voice=voice,
+                rate=rate,
+                volume=volume,
+                pitch=pitch)
+        
+        async for chunk in communicate.stream():
+            if chunk["type"] == "audio":
+                audio_data.write(chunk["data"])
+        
+        data = {
+            "text": text, 
+            "voice": voice,
+            "rate": rate,
+            "volume": volume,
+            "pitch": pitch
+        }
+
+        logger.debug(f"Edge 请求 data 为: {data}")
+        logger.info(f"Edge TTS 成功: {text}")
+        
+        return audio_data.getvalue()


### PR DESCRIPTION
增加了Edge TTS的支持

## Summary by Sourcery

在现有的 TTS 后端基础上，新增对 Edge TTS 的支持，并将其作为可配置的文本转语音服务。

New Features:
- 引入 Edge TTS 作为新的 TTS 服务类型，并将其集成到服务选择流程中。
- 为 Edge TTS 添加语音、语速、音量和音调的配置选项，包括预设的中文语音配置。
- 在图形界面（GUI）中开放 Edge TTS 设置，提供专门的控件用于选择语音并调整韵律（prosody）参数。

Enhancements:
- 扩展核心配置和服务元数据，以识别新的 Edge TTS 服务组及其相关参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for Edge TTS as a configurable text-to-speech service alongside existing TTS backends.

New Features:
- Introduce Edge TTS as a new TTS service type and integrate it into the service selection flow.
- Add configuration options for Edge TTS voice, rate, volume, and pitch, including predefined Chinese voice presets.
- Expose Edge TTS settings in the GUI with dedicated controls for selecting voice and adjusting prosody parameters.

Enhancements:
- Extend core configuration and service metadata to recognize the new Edge TTS service group and its parameters.

</details>