### PR TITLE
fix: 给音频测试添加纯空格检测

### DIFF
--- a/src/gui/view/audio_test.py
+++ b/src/gui/view/audio_test.py
@@ -268,7 +268,8 @@ class AudioTestInterface(ScrollArea):
     async def _on_test_button_clicked(self) -> None:
         """测试按钮点击事件"""
         text = self.text_edit.toPlainText()
-        if not text:
+        # 去除首尾空格后如果为空直接返回
+        if not text.strip():
             return
         try:
             tts_service = get_tts_service()


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

错误修复：
- 在开始音频测试时，忽略仅包含空白字符的输入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ignore inputs that contain only whitespace characters when starting an audio test.

</details>